### PR TITLE
Prevent error when command used in server console

### DIFF
--- a/lua/moderator/libs/sh_commands.lua
+++ b/lua/moderator/libs/sh_commands.lua
@@ -294,6 +294,11 @@ if (SERVER) then
 	end)
 
 	concommand.Add("mod", function(client, command, arguments)
+		if (!IsValid(client)) then
+			print("This command can only be run by a player")
+			return
+		end
+
 		if (arguments[1] == "menu") then
 			return client:ConCommand("mod_menu")
 		end


### PR DESCRIPTION
To prevent an error occurrding when the "mod" command is used in the console, I prevented it from being used. This could be made better by writing an alternative PrintMessage method that instead of being an instance method, it would be a global that works in a way similar to the following;

```
function ModPrint(ent, type, message)
    if (!IsValid(ent)) then
        print(message)
    else
        ent:PrintMessage(type, message)
    end
end
```
